### PR TITLE
make podspec same as https://github.com/CocoaPods/Specs/blob/master/IMAP...

### DIFF
--- a/IMAPClient.podspec
+++ b/IMAPClient.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
-  s.name     = 'imap'
-  s.version  = '0.0.1'
+  s.name     = 'IMAPClient'
+  s.version  = '0.0.2'
   s.license  = 'MIT'
   s.summary  = 'An asynchrounous IMAP client for iOS.'
   s.homepage = 'https://github.com/bcoe/IMAPClient'
   s.author   = { 'bcoe' => 'bencoe@gmail.com' }
-  s.source   = { :git => 'git://github.com/bcoe/IMAPClient.git', :tag => '0.0.1' }
+  s.source   = { :git => 'https://github.com/bcoe/IMAPClient.git', :tag => '0.0.2' }
   s.description = 'An asynchrounous IMAP client for iOS.'
   s.platform = :ios
   s.source_files = 'Classes', 'Classes/**/*.{h,m}'


### PR DESCRIPTION
This command was failed.

```
pod 'IMAPClient'
```

But this command returns "IMAPClient"

```
pod list
```

I think the reason is unmatched podspec between IMAPClient and [CocoaPods](https://github.com/CocoaPods/Specs/blob/master/IMAPClient/0.0.2/IMAPClient.podspec).
And after update the source file, I’ve confirmed pod install success  by following Podfile :

```
platform :ios
pod 'IMAPClient', :git => 'https://github.com/amazedkoumei/IMAPClient.git',     :commit => 'b9fc6756adeb5ee0144f97094be236cb96d90c3b'
```

before update, the cases of Podfile I've tried are as follows:
#### success case

```
platform :ios
pod 'imap', :git => "https://github.com/bcoe/IMAPClient.git"
```
#### error case1

```
platform :ios
pod 'IMAPClient'
```
## 

"pod install" returns

```
[!] Cache unable to find git reference `0.0.2' for `https://github.com/bcoe/IMAPClient.git'.
```
#### error case2

```
platform :ios
pod 'IMAPClient', :git => "https://github.com/bcoe/IMAPClient.git"
```
## 

"pod install" returns

```
[!] No podspec found for `IMAPClient' in from `https://github.com/bcoe/IMAPClient.git'
```
#### error case3

```
platform :ios
pod 'imap'
```
## 

"pod install" returns

```
[!] Unable to find a pod named `imap'
```
